### PR TITLE
Fix up ImageSharp implementation.

### DIFF
--- a/ImageSharp/Program.cs
+++ b/ImageSharp/Program.cs
@@ -1,38 +1,29 @@
 ﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
-// Create an empty image canvas that is 256 x 256 px by ImageSharp.
-using var canvas = new Image<Rgba32>(256, 256);
+// Create a canvas from the table image.
+using var canvas = await LoadImage("./assets/table.png");
 
-// Load the table image and draw it on the canvas
-using var tableImage = await LoadImage("./assets/table.png");
-canvas.Mutate(ctx => ctx.DrawImage(tableImage, 1f));
+// Clear out any preexisting color palette if the image has one.
+// The encoder will automatically create a new palette if needed.
+PngMetadata metadata = canvas.Metadata.GetPngMetadata();
+metadata.ColorTable = null;
 
 // Load the apple image and draw it on the canvas
 using var appleImage = await LoadImage("./assets/apple.png");
 canvas.Mutate(ctx => ctx.DrawImage(appleImage, new Point(96, 50), 1f));
 
-// Get the canvas image as a byte array.
-var memoryStream = new MemoryStream();
-await canvas.SaveAsPngAsync(memoryStream);
-var imageBytes = memoryStream.ToArray();
-
 // Save it.
-await SaveImage("image.png", imageBytes);
+await SaveImage(canvas, "image.png");
 
 Console.WriteLine("The image was saved.");
 Console.ReadLine();
 
-async ValueTask<Image> LoadImage(string imageName)
-{
-    var imageBytes = await File.ReadAllBytesAsync(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, imageName));
+// Load as Rgba32 to ensure we always have an alpha channel for transparency.
+Task<Image<Rgba32>> LoadImage(string imageName)
+    => Image.LoadAsync<Rgba32>(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, imageName));
 
-    // Create a ImageSharp.Image from the byte array.
-    return Image.Load(imageBytes);
-}
-
-async ValueTask SaveImage(string imageName, byte[] imageBytes)
-{
-    await File.WriteAllBytesAsync(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, imageName), imageBytes);
-}
+Task SaveImage(Image image, string imageName)
+    => image.SaveAsPngAsync(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, imageName));


### PR DESCRIPTION
This PR updates the ImageSharp sample to use best practice and optimize the workflow. I'll comment on the PR diff to explain the changes.

A you can see though in the screenshot the output is 2x smaller with ImageSharp.

<img alt="image" src="https://github.com/sample-by-jsakamoto/CSharp-Blending-Two-Images/assets/385879/f2f58abd-4fd7-43a8-8881-a0d66ec5c5f7">

I hope this is useful to you. 






































































































